### PR TITLE
Fix cyclic reference error

### DIFF
--- a/server/commands/casing.py
+++ b/server/commands/casing.py
@@ -4,7 +4,6 @@ import random
 from server import database
 from server.constants import TargetType
 from server.exceptions import ClientError, ServerError, ArgumentError
-from server.tsuserver import testify_enabled
 
 from . import mod_only
 
@@ -625,8 +624,8 @@ def ooc_cmd_testimony(client, arg):
     Usage: /testimony
     """
     #Check if testifying is enabled on the server
-    if not testify_enabled:
-        _testify_distabled(client)
+    if not client.area.server.testify_enabled:
+        _notify_testify_disabled(client)
         return
     
     if len(arg) != 0:
@@ -655,8 +654,8 @@ def ooc_cmd_cleartesti(client, arg):
     """
     
     #Check if testifying is enabled on the server
-    if not testify_enabled:
-        _testify_disabled(client)
+    if not client.area.server.testify_enabled:
+        _notify_testify_disabled(client)
         return
     
     if len(arg) != 0:
@@ -669,7 +668,7 @@ def ooc_cmd_cleartesti(client, arg):
         client.area.testimony.title = ''
         client.send_ooc('You have cleared the testimony.')
      
-def _testify_disabled(client):
+def _notify_testify_disabled(client):
     """Simply an encapsulated way of telling the player the testimony
     functionality is disabled"""
     client.send_ooc('The Testify functionality is disabled on this server')

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -28,7 +28,6 @@ from time import localtime, strftime, time
 
 from .. import commands
 from server import database
-from server.tsuserver import testify_enabled
 from server.fantacrypt import fanta_decrypt
 from server.constants import ESCAPE_CHARACTERS
 from server.exceptions import ClientError, AreaError, ArgumentError, ServerError
@@ -558,7 +557,7 @@ class AOProtocol(asyncio.Protocol):
                 self.client.send_ooc('You don\'t any areas!')
                 return
             text = ' '.join(part[1:])
-        elif testify_enabled:
+        elif self.client.area.server.testify_enabled:
             if text.startswith('/testify '): # Start a new testimony in this area.
                 part = text.split(' ')
                 text = ' '.join(part[1:]) # remove command

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -128,7 +128,7 @@ class TsuServer3:
             asyncio.ensure_future(self.idle_loop())
         
         if self.config['testify_enabled']:
-            self.testify_enabled = True
+            self.testify_enabled = self.config['testify_enabled']
 
         asyncio.ensure_future(self.schedule_unbans())
 


### PR DESCRIPTION
Fixed a cyclic reference error caused by the server importing itself within subscripts, and passes the value of testify_enabled now by direct reference from the server through the client's area